### PR TITLE
Add token blacklisting - Fixes #7

### DIFF
--- a/api.py
+++ b/api.py
@@ -112,6 +112,10 @@ def verify_token():
     return '{ "uid": "' + result + '" }'
 
 
+#Blacklist token
+@app.route("/blacklist/<token:string>", methods=["GET", "POST"])
+def blacklist_token(token):
+    auth.blacklist_token(token)
 
 
 


### PR DESCRIPTION
This adds a `blacklist/<token:string>` endpoint to the API for the Auth service, to be invoked every time a user logs out of the mobile app.